### PR TITLE
Travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
 
 before_script: gem install awesome_bot
 
-script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --allow-ssl --skip-save-results
+script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --allow-ssl --skip-save-results --set-timeout 100
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
 
 before_script: gem install awesome_bot
 
-script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --allow-ssl --skip-save-results --set-timeout 100
+script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --skip-save-results --set-timeout 100
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
 
 before_script: gem install awesome_bot
 
-script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --skip-save-results
+script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --allow-ssl --skip-save-results --set-timeout 100
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
 
 before_script: gem install awesome_bot
 
-script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --allow-ssl --skip-save-results --set-timeout 100
+script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --allow-ssl --skip-save-results
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
 
 before_script: gem install awesome_bot
 
-script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --skip-save-results --set-timeout 100
+script: awesome_bot _posts/*.md  support/**/*.md  support/*.md products/*.md solutions/*.md contact/*.md  pulse/*.md --allow-dupe --allow-redirect --skip-save-results
 notifications:
   email: false


### PR DESCRIPTION
One of the links `https://www.usni.org/magazines/proceedings/2014/february/search-standard-answer` was throwing 503 error during travis build, due to which the checks were failing. But the link was working fine and was opening without any issues. The latest build shows no issues with that link. Hence to prevent failure of travis build due to unbroken links , following additional params are added to `.travis.yml` file.
- allow-ssl
- set timeout