### PR TITLE
fix(brochures): Fixing modem brochure and modem specification link

### DIFF
--- a/_posts/2019-06-11-UnetStack-Newsletter.md
+++ b/_posts/2019-06-11-UnetStack-Newsletter.md
@@ -36,6 +36,6 @@ Do not hesitate to approach any team member for information about this latest re
 Our new brochures have arrived!
 We will be distributing, for the first time, our new brochures showing in detail the new specifications of our modems.
 You can have a sneak preview using the following links:
--  [Underwater Modems](https://subnero.com/brochures/Subnero-Modem-v4.0.pdf){:target="_blank"}
--  [Underwater Modems specifications](https://subnero.com/brochures/Subnero-Modem-Specifications-v4.0.pdf){:target="_blank"}
+-  [Underwater Modems](https://subnero.com/brochures/Subnero-Modem-Brochure.pdf){:target="_blank"}
+-  [Underwater Modems specifications](https://subnero.com/brochures/Subnero-Modem-Specifications.pdf){:target="_blank"}
 -  [UnetStack 3](https://subnero.com/brochures/UnetStack-Brochure-v3.0.pdf){:target="_blank"}

--- a/_posts/2020-11-19-Subnero-at-SIWW-online.md
+++ b/_posts/2020-11-19-Subnero-at-SIWW-online.md
@@ -14,7 +14,7 @@ Subnero had a virtual booth with personnel available online, permanently, to att
 
 We took this opportunity to display our new [white paper about the SWAN](https://subnero.com/brochures/SWAN-White-paper.pdf), describing the different components of our networked solution as well as to create new posters (as per picture below). 
 
-We also displayed the details of our [underwater modems](https://subnero.com/brochures/Subnero-Modem-v4.0.pdf), that can be used for water data collection underwater.
+We also displayed the details of our [underwater modems](https://subnero.com/brochures/Subnero-Modem-Brochure.pdf), that can be used for water data collection underwater.
 
 The show was very well attended and had a number of very interested talks.
 

--- a/brochures/index.html
+++ b/brochures/index.html
@@ -8,12 +8,8 @@ title: Brochures
 <h1> Brochures </h1>
 <div style="padding-left: 20%">
 	<div class="brochure-container">
-		<a href="{{site.baseurl}}/brochures/Subnero-Modem-v4.0.pdf"><img class="brochure-thumb" src="{{site.baseurl}}/brochures/modem4.jpg"></a>
-		<a href="{{site.baseurl}}/brochures/Subnero-Modem-v4.0.pdf" target="_blank" style="font-size: 1.2em;">Subnero Underwater Modems</a>
-	</div>
-	<div class="brochure-container">
-		<a href="{{site.baseurl}}/brochures/subnero-highspeedmodem.pdf"><img class="brochure-thumb" src="modem-hs.jpg"></a>
-		<a  href="{{site.baseurl}}/brochures/subnero-highspeedmodem.pdf" target="_blank" style="font-size: 1.2em;">Subnero High Speed Modem</a>
+		<a href="{{site.baseurl}}/brochures/Subnero-Modem-Brochure.pdf"><img class="brochure-thumb" src="{{site.baseurl}}/brochures/modem4.jpg"></a>
+		<a href="{{site.baseurl}}/brochures/Subnero-Modem-Brochure.pdf" target="_blank" style="font-size: 1.2em;">Subnero Underwater Modems</a>
 	</div>
 	<div class="brochure-container">
 		<a href="{{site.baseurl}}/brochures/subnero-swan.pdf"><img class="brochure-thumb" src="swan.jpg"></a>
@@ -28,16 +24,12 @@ title: Brochures
 	  <a  href="{{site.baseurl}}/brochures/SWAN-White-paper.pdf" target="_blank" style="font-size: 1.2em;">Subnero Water Assessment Network (SWAN) White Paper</a>
 	</div>
 	<div class="brochure-container">
-		<a href="{{site.baseurl}}/brochures/Subnero-Modem-Specifications-v4.0.pdf"><img class="brochure-thumb" src="spec.jpg"></a>
-		<a  href="{{site.baseurl}}/brochures/Subnero-Modem-Specifications-v4.0.pdf" target="_blank" style="font-size: 1.2em;">Subnero Underwater Modems Technical Specifications</a>
+		<a href="{{site.baseurl}}/brochures/Subnero-Modem-Specifications.pdf"><img class="brochure-thumb" src="spec.jpg"></a>
+		<a  href="{{site.baseurl}}/brochures/Subnero-Modem-Specifications.pdf" target="_blank" style="font-size: 1.2em;">Subnero Underwater Modems Technical Specifications</a>
 	</div>
 	<div class="brochure-container">
 		<a href="{{site.baseurl}}/brochures/UnetStack-Brochure-v3.0.pdf"><img class="brochure-thumb" src="unetstack3.jpg"></a>
 		<a  href="{{site.baseurl}}/brochures/UnetStack-Brochure-v3.0.pdf" target="_blank" style="font-size: 1.2em;">UnetStack</a>
-	</div>
-	<div class="brochure-container">
-		<a href="{{site.baseurl}}/brochures/subnero-arecorder.pdf"><img class="brochure-thumb" src="aRec.jpg"></a>
-		<a  href="{{site.baseurl}}/brochures/subnero-arecorder.pdf" target="_blank" style="font-size: 1.2em;">Subnero aRecorder</a>
 	</div>
 </div>
 


### PR DESCRIPTION
- Fixed the renamed brochures in the below pages:
  _posts/2019-06-11-UnetStack-Newsletter.md
  _posts/2020-11-19-Subnero-at-SIWW-online.md
  brochures/index.html

- Removed brochure links for `high-speed modems` and `arecorder`.