### PR TITLE
Add SEO meta tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Site settings
 title: Subnero
-description: The future of underwater wireless.
+description: "Subnero designs and manufactures advanced underwater acoustic modems and networking solutions, enabling reliable wireless communications for ocean monitoring, subsea IoT and marine robotics."
+keywords: "underwater communication, acoustic modems, underwater acoustic modem, subsea wireless, marine data communication, underwater telemetry, underwater networking, underwater sensor networks, subsea IoT, ocean technology"
 url: "http://subnero1.github.io/"
 twitter_username: subnero
 github_username:  subnero1

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,12 @@
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="keywords" content="{% if page.keywords %}{{ page.keywords }}{% else %}{{ site.keywords }}{% endif %}">
+  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
+  <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <meta property="og:image" content="{{ site.default_image | prepend: site.baseurl | prepend: site.url }}">
+  <meta property="og:type" content="website">
   {% if site.categories != "" %}
   {% include tag.html %}
   {% endif %}


### PR DESCRIPTION
## Summary
- enrich SEO description and keywords
- add meta keywords and Open Graph tags for SEO

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_683f4a38a14c832f8f39963c150dd0a9