### PR TITLE
Some more channel -> receiver substitutions

### DIFF
--- a/_faq/faq07.md
+++ b/_faq/faq07.md
@@ -5,9 +5,9 @@ search_content: What configurations of Subnero modems are available?
 faq_section: products
 ---
 
-Subnero modems are available in Standalone, OEM, and Multichannel configurations, each suited for specific use cases:
+Subnero modems are available in Standalone, OEM, and Multireceiver configurations, each suited for specific use cases:
 - **Standalone Configuration**: Pressure-housed and ideal for surface or seabed deployments.
 - **OEM Configuration**: Compact and designed for seamless integration into platforms like AUVs.
-- **Multichannel Configuration**: Equipped with multiple receiving channels, it is designed for enhanced communication performance.
+- **Multireceiver Configuration**: Equipped with multiple receiving channels, it is designed for enhanced communication performance.
 
 For more information about the different configurations, visit: [https://subnero.com/products/modem.html](https://subnero.com/products/modem.html)

--- a/_faq/faq09.md
+++ b/_faq/faq09.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: What is the multichannel configuration and what are its advantages?
-search_content: What is the multichannel configuration and what are its advantages?
+title: What is the multireceiver configuration and what are its advantages?
+search_content: What is the multireceiver configuration and what are its advantages?
 faq_section: products
 ---
 
-The multichannel configuration features multiple receiving channels for enhanced communication performance and supports additional functionalities like positioning and passive acoustic monitoring.
+The multireceiver configuration features multiple receiving channels for enhanced communication performance and supports additional functionalities like positioning and passive acoustic monitoring.
 
 **Relevant Links**
 - [Brochure](https://subnero.com/brochures/Subnero-MR-Modems.pdf)

--- a/_posts/2017-12-12-Underwater-modem-with-multiple-hydrophones.md
+++ b/_posts/2017-12-12-Underwater-modem-with-multiple-hydrophones.md
@@ -27,4 +27,4 @@ bbmsg = receive(RxBasebandSignalNtf, 2000)
 signal = bbmsg.signal
 ```
 
-Since the recording is requested on the secondary data acquisition system containing multiple channels, the recorded data stored in `signal` is interleaved.
+Since the recording is requested on the secondary data acquisition system containing multiple receivers, the recorded data stored in `signal` is interleaved.

--- a/products/wnc-m25mss4+xch.md
+++ b/products/wnc-m25mss4+xch.md
@@ -3,7 +3,7 @@ layout: page
 title: WNC-M25MSS4+xCh
 banner : images/banner-multichannel-mf.jpg
 thumbnail : images/thumbnail-wnc-m25mss4+xch.png
-excerpt: Subnero's underwater acoustic smart modems with multiple channels for high-speed data acquisition.
+excerpt: Subnero's underwater acoustic smart modems with multiple receivers for high-speed data acquisition.
 categories: wnc
 section_id: products
 ---

--- a/products/wnc-s40hss4+xch.md
+++ b/products/wnc-s40hss4+xch.md
@@ -3,7 +3,7 @@ layout: page
 title: WNC-S40HSS4+xCh
 banner : images/banner-multichannel-hf.jpg
 thumbnail : images/thumbnail-wnc-s40hss4+xch.png
-excerpt: Subnero's underwater acoustic smart modems with multiple channels for high-speed data acquisition.
+excerpt: Subnero's underwater acoustic smart modems with multiple receivers for high-speed data acquisition.
 categories: wnc
 section_id: products
 ---


### PR DESCRIPTION
Replaces "channel" with "receiver" in a couple more places (cf https://github.com/subnero1/subnero1.github.io/pull/334). 

I've tried to stick to substitutions here that to me are clearly necessary. Beyond this PR, there's a couple more instances of "channel" that I'd probably also have replaced with "receiver" (e.g. there are still 19 hits for "receiving channel"), but where the current formulation seems also acceptable to me. 