### PR TITLE
Job title in modal special character fix

### DIFF
--- a/_includes/job-modals.html
+++ b/_includes/job-modals.html
@@ -45,10 +45,10 @@
     {% assign job_listings = site.jobs | where: "active", true | sort: "order" %}
     {% for job in job_listings %}
       "{{ job.id }}": {
-        "title": "{{ job.title | escape_once }}",
-        "type": "{{ job.employment_type | escape_once }}",
-        "location": "{{ job.location | escape_once }}",
-        "apply_url": "{{ job.apply_url | escape_once }}"
+        "title": {{ job.title | jsonify }},
+        "type": {{ job.employment_type | jsonify }},
+        "location": {{ job.location | jsonify }},
+        "apply_url": {{ job.apply_url | jsonify }}
       }{% if forloop.last == false %},{% endif %}
     {% endfor %}
   });


### PR DESCRIPTION
This PR fixes outputting the special characters in the job details modal. (Discussion https://discord.com/channels/1071020492070342736/1519125450608218112/1519125594103742474)

<img width="777" height="144" alt="Screenshot 2026-06-24 at 7 38 53 AM" src="https://github.com/user-attachments/assets/06ba6f3c-f37a-4a08-8741-2fe833a9670c" />
