### PR TITLE
Noindex the staging build

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
 
   <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% elsif page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-  {% if page.noindex %}
+  {% if page.noindex or site.github.repository_name == 'website-staging' %}
   <meta name="robots" content="noindex, follow">
   {% endif %}
 


### PR DESCRIPTION
The same branch is deployed to subnero1/website-staging, which GitHub Pages serves publicly at subnero.com/website-staging/. Google has indexed at least four of those pages, and /website-staging/industries/marine-robotics is ranking at position 6.5 and has taken a click, competing with its own production equivalent.

One line in _includes/head.html, extending the existing page level noindex condition to also fire when the build detects it is running in the website-staging repository. Since both repos build from the same branch, the check has to happen at build time; GitHub Pages does not accept a --config flag.

The test is written as an equality check on purpose. Inverting it, noindex unless the repo is subnero1.github.io, would place a sitewide noindex on production if jekyll-github-metadata were ever unavailable. This form fails safe.

No effect on production. Verify after deploy by confirming the robots meta is present on a /website-staging/ page and absent on the matching production page.