### PR TITLE
Fix broken link check workflow

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Generate link check config with internal link replacement patterns
       run: |
-        jq --arg ws "$GITHUB_WORKSPACE" '. + {
+        jq --arg ws "/github/workspace" '. + {
             "replacementPatterns": [
               {"pattern": "^(/[^#?]+/)$",   "replacement": ("file://" + $ws + "$1")},
               {"pattern": "^(/[^#?.]+)$",   "replacement": ("file://" + $ws + "$1.md")},

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -19,18 +19,10 @@ jobs:
               {"pattern": "^(/[^#?]+\\.[A-Za-z0-9]+)$",   "replacement": ("file://" + $ws + "$1")}
             ]
           }' \
-          .github/workflows/markdown.links.config.json > "$RUNNER_TEMP/mlc.config.json"
+          .github/workflows/markdown.links.config.json > "$GITHUB_WORKSPACE/.github/workflows/mlc.config.generated.json"
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       id: checker
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
-        config-file: '${{ runner.temp }}/mlc.config.json'
-    - uses: slackapi/slack-github-action@v1
-      if: failure()
-      id: slack
-      with:
-        payload: '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":"Website Broken Link Check Status : *${{steps.checker.outcome}}*. \n\n Details : https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} "}}]}'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        config-file: '.github/workflows/mlc.config.generated.json'

--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -16,7 +16,7 @@
         { "pattern" : "^https?://podcasts\\.apple\\.com/"},
         { "pattern" : "^https://subnero\\.com/solutions/swan\\.html"}
     ],
-    "aliveStatusCodes": [200, 202, 206, 301, 302, 303, 304, 403, 429, 999],
+    "aliveStatusCodes": [200, 202, 206, 301, 302, 303, 304, 403, 418, 429, 999],
     "retryOn429": true,
     "retryCount": 5,
     "fallbackRetryDelay": "30s",


### PR DESCRIPTION
The scheduled broken-link-check job has been failing on every run, reporting hundreds of false positives and never producing a usable signal. Root causes were two Docker container path mismatches:

1. The generated markdown-link-check config file was written to $RUNNER_TEMP, a host path not mounted into the checker's container, so the config (ignore patterns, alive status codes, internal link replacement patterns) silently never loaded.
2. Once that was fixed, the internal-link replacement patterns still baked in $GITHUB_WORKSPACE, the host-side path, instead of the container's fixed mount point /github/workspace, so every internal link still resolved to a path that doesn't exist in the container.

Also removed the Slack notification step (webhook no longer active, Slack unused) and allow-listed IEEE Xplore's 418 anti-bot response alongside the existing 403/429/999 exceptions for other publishers.

Verified with two workflow_dispatch runs on this branch: first run after fix #1 still failed on the second bug; run after fix #2 passed clean (run 31184596307).