### PR TITLE
Fix Google Search Console coverage issues

### DIFF
--- a/about/trust.md
+++ b/about/trust.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/about/trust.html"
+redirect_to: /about/
+---

--- a/dev/rs232.md
+++ b/dev/rs232.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/dev/rs232.html"
+redirect_to: /products/wnc/gen4x/accessories/cables.html
+---

--- a/distributors/index.md
+++ b/distributors/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /contact/
+---

--- a/distributors/optimos.md
+++ b/distributors/optimos.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/distributors/optimos.html"
+redirect_to: /contact/
+---

--- a/distributors/yottec.md
+++ b/distributors/yottec.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/distributors/yottec.html"
+redirect_to: /contact/
+---

--- a/people/prasad/index.md
+++ b/people/prasad/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /about/
+---

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/privacy-policy.html"
+redirect_to: /about/
+---

--- a/products/gen4x/accessories/index.md
+++ b/products/gen4x/accessories/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/accessories/
+---

--- a/products/gen4x/l12l/index.md
+++ b/products/gen4x/l12l/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/l12l/
+---

--- a/products/gen4x/m25m/index.md
+++ b/products/gen4x/m25m/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/m25m/
+---

--- a/products/gen4x/s40h/index.md
+++ b/products/gen4x/s40h/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/s40h/
+---

--- a/products/swan.md
+++ b/products/swan.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/products/swan.html"
+redirect_to: /case-study/2022/09/08/Redefining-water-quality-monitoring-with-Blue-Robotics-and-the-SWAN.html
+---

--- a/products/swis/index.md
+++ b/products/swis/index.md
@@ -3,7 +3,6 @@ layout: default
 title:  Subnero Wireless Integrated Suite (SWIS)
 banner : images/hero-swis.jpg
 excerpt: A modular underwater operations platform that integrates communication, sensing, and automation for seamless subsea data collection.
-canonical: /products/swis/swis-adcp/
 ---
 
 <section class="page-hero gen4x" style='background-image: url({{site.baseurl}}/{{page.banner}});'>

--- a/products/swis/swis-adcp/index.md
+++ b/products/swis/swis-adcp/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/swis/swis-adcp.html
+---

--- a/products/unet/index.md
+++ b/products/unet/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/unetstack/
+---

--- a/products/wnc-m25mse3.md
+++ b/products/wnc-m25mse3.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/products/wnc-m25mse3.html"
+redirect_to: /products/wnc/
+---

--- a/products/wnc/gen4/cables.md
+++ b/products/wnc/gen4/cables.md
@@ -5,7 +5,7 @@ banner : images/banner-mechanical.jpg
 thumbnail: images/thumbnail-cables.png
 categories: accessories
 excerpt: Cables for Subnero underwater acoustic smart modems.
-canonical: /products/wnc/gen4x/cables/
+canonical: /products/wnc/gen4x/accessories/cables.html
 ---
 
 <div class='full tall' style='background-image: url({{site.baseurl}}/{{page.banner}});'>

--- a/products/wnc/gen4/coprocessor.md
+++ b/products/wnc/gen4/coprocessor.md
@@ -5,7 +5,7 @@ banner : images/banner-electrical.jpg
 thumbnail: images/thumbnail-coprocessor.png
 categories: accessories
 excerpt: Co-processor for Subnero underwater acoustic smart modems.
-canonical: /products/wnc/gen4x/co-processors/
+canonical: /products/wnc/gen4x/accessories/co-processors.html
 ---
 
 <div class='full tall' style='background-image: url({{site.baseurl}}/{{page.banner}});'>

--- a/products/wnc/gen4/hull.md
+++ b/products/wnc/gen4/hull.md
@@ -5,7 +5,7 @@ banner : images/banner-mechanical.jpg
 thumbnail: images/thumbnail-hull.png
 categories: accessories
 excerpt: Additional hull options for Subnero underwater acoustic smart modems.
-canonical: /products/wnc/gen4x/hull-options/
+canonical: /products/wnc/gen4x/accessories/hull-options.html
 ---
 
 <div class='full tall' style='background-image: url({{site.baseurl}}/{{page.banner}});'>

--- a/products/wnc/gen4/storage.md
+++ b/products/wnc/gen4/storage.md
@@ -5,7 +5,7 @@ banner : images/banner-electrical.jpg
 thumbnail: images/thumbnail-storage.png
 categories: accessories
 excerpt: Additional storage for Subnero underwater acoustic smart modems.
-canonical: /products/wnc/gen4x/storage/
+canonical: /products/wnc/gen4x/accessories/storage.html
 ---
 
 <div class='full tall' style='background-image: url({{site.baseurl}}/{{page.banner}});'>

--- a/products/wnc/gen4x/cables/index.md
+++ b/products/wnc/gen4x/cables/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/accessories/cables.html
+---

--- a/products/wnc/gen4x/co-processors/index.md
+++ b/products/wnc/gen4x/co-processors/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/accessories/co-processors.html
+---

--- a/products/wnc/gen4x/hull-options/index.md
+++ b/products/wnc/gen4x/hull-options/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/accessories/hull-options.html
+---

--- a/products/wnc/gen4x/storage/index.md
+++ b/products/wnc/gen4x/storage/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /products/wnc/gen4x/accessories/storage.html
+---

--- a/redirects/connected-ocean-2025.md
+++ b/redirects/connected-ocean-2025.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/feature/2025/12/11/A-Connected-Ocean-Begins-in-Singapore-with-Underwater-Cellular-Network-Deployment.html"
+redirect_to: /case-study/partnership/2025/12/11/A-Connected-Ocean-Begins-in-Singapore-with-Underwater-Cellular-Network-Deployment.html
+---

--- a/redirects/connecting-ocean-2016.md
+++ b/redirects/connecting-ocean-2016.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/press/faeture/2016/12/20/Connecting-the-ocean-to-the-internet.html"
+redirect_to: /press/feature/2016/12/20/Connecting-the-ocean-to-the-internet.html
+---

--- a/redirects/hydrosurv-2026.md
+++ b/redirects/hydrosurv-2026.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/partnership/2026/06/03/Subnero-HydroSurv-Collaborate-on-Autonomous-Subsea-Data-Operations.html"
+redirect_to: /partnership/2026/06/08/Subnero-HydroSurv-Collaborate-on-Autonomous-Subsea-Data-Operations.html
+---

--- a/redirects/jobs-11-software-engineer-applications-algorithms.md
+++ b/redirects/jobs-11-software-engineer-applications-algorithms.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/jobs/11-software-engineer-applications-algorithms.html"
+redirect_to: /careers/
+---

--- a/redirects/jobs-12-deep-tech-content-engagement-specialist.md
+++ b/redirects/jobs-12-deep-tech-content-engagement-specialist.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/jobs/12-deep-tech-content-engagement-specialist.html"
+redirect_to: /careers/
+---

--- a/redirects/jobs-13-marine-acoustic-calibration-system-development-internship.md
+++ b/redirects/jobs-13-marine-acoustic-calibration-system-development-internship.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/jobs/13-marine-acoustic-calibration-system-development-internship.html"
+redirect_to: /careers/
+---

--- a/redirects/jobs-13-mechanical-and-product-designer-subsea-systems.md
+++ b/redirects/jobs-13-mechanical-and-product-designer-subsea-systems.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/jobs/13-mechanical-and-product-designer-subsea-systems.html"
+redirect_to: /careers/
+---

--- a/redirects/making-waves-2023.md
+++ b/redirects/making-waves-2023.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/wnc/2023/08/02/Making-Waves-Overseas.html"
+redirect_to: /corporate/partnership/2023/08/02/Making-Waves-Overseas.html
+---

--- a/redirects/products-unetstack.md
+++ b/redirects/products-unetstack.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/products/unetstack.html"
+redirect_to: /products/wnc/unetstack/
+---

--- a/redirects/products-wnc-l12lso4-dir.md
+++ b/redirects/products-wnc-l12lso4-dir.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/products/wnc-l12lso4/"
+redirect_to: /products/wnc/gen4/wnc-l12lso4.html
+---

--- a/redirects/robot-swans-2018.md
+++ b/redirects/robot-swans-2018.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/press/2018/01/16/Singapore-uses-robot-swans-to-monitor-water-quality-in-reservoirs.html"
+redirect_to: /press/2018/01/15/Robot-swans-to-help-monitor-water-quality-in-Singapore.html
+---

--- a/redirects/sauvc-2014.md
+++ b/redirects/sauvc-2014.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/sauvc/2014/03/13/The-Singapore-Autonomous-Underwater-Vehicle-Challenge-is-Back.html"
+redirect_to: /event/2014/03/13/The-Singapore-Autonomous-Underwater-Vehicle-Challenge-is-Back.html
+---

--- a/redirects/swan-wqm-2022.md
+++ b/redirects/swan-wqm-2022.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/wqm/2022/09/08/Redefining-water-quality-monitoring-with-Blue-Robotics-and-the-SWAN.html"
+redirect_to: /case-study/2022/09/08/Redefining-water-quality-monitoring-with-Blue-Robotics-and-the-SWAN.html
+---

--- a/redirects/underwater-internet-2014.md
+++ b/redirects/underwater-internet-2014.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/news/2014/10/13/Think-underwater-internet-is-impossible.html"
+redirect_to: /press/2014/10/13/Think-underwater-internet-is-impossible.html
+---

--- a/redirects/unetstack-hilsim.md
+++ b/redirects/unetstack-hilsim.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/unetstack/hilsim.html"
+redirect_to: /products/wnc/unetstack/hilsim.html
+---

--- a/redirects/unetstack-unetcube.md
+++ b/redirects/unetstack-unetcube.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/unetstack/unetcube.html"
+redirect_to: /products/wnc/unetstack/unetcube.html
+---

--- a/redirects/unetstack-unetsim.md
+++ b/redirects/unetstack-unetsim.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/unetstack/unetsim.html"
+redirect_to: /products/wnc/unetstack/unetsim.html
+---

--- a/redirects/wired-2014.md
+++ b/redirects/wired-2014.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/press/2014/05/29/Subnero-featured-in-Wired-magazine.html"
+redirect_to: /press/2014/06/09/Subnero-featured-In-Wired-magazine-How-Do-Submarines-Get-Online.html
+---

--- a/solutions/swan.md
+++ b/solutions/swan.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/solutions/swan.html"
+redirect_to: /case-study/2022/09/08/Redefining-water-quality-monitoring-with-Blue-Robotics-and-the-SWAN.html
+---

--- a/support/wnc/index.md
+++ b/support/wnc/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /support/
+---

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/terms-and-conditions.html"
+redirect_to: /about/
+---

--- a/trust.md
+++ b/trust.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/trust.html"
+redirect_to: /about/
+---

--- a/trustcenter.md
+++ b/trustcenter.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: "/trustcenter.html"
+redirect_to: /about/
+---


### PR DESCRIPTION
## Summary

Google Search Console (export of 2026-08-12) reported 83 not-found pages, 16 duplicates without user-selected canonical, and related indexing problems. This PR fixes everything actionable.

**Root cause of the duplicate bucket**: five pages declared `canonical:` front matter pointing to trailing-slash URLs that 404 in production (verified live). Google ignores an invalid canonical and flags the page as a duplicate.

## Changes

- **Canonical fixes (5)**: the four Gen4 accessory pages now canonical to the real Gen4X accessory URLs; the SWIS index canonical is removed so the landing page indexes itself
- **Redirect stubs (43)**, all `layout: redirected`, excluded from the sitemap:
  - Old pulse post URLs whose categories or dates changed over time (9, including the old `faeture` typo category)
  - Retired job posting URLs to `/careers/` (4)
  - UnetStack shortlinks `/unetstack/{hilsim,unetcube,unetsim}` to their product pages
  - Legacy `/products/gen4x/` directory URLs to `/products/wnc/gen4x/`
  - The five dead canonical-target URLs
  - Distributor pages to `/contact/`, `/people/prasad/` to `/about/`, `/support/wnc/` to `/support/`
  - Discontinued SWAN product (3 URLs) to its 2022 case study
  - Trust/legal shortlinks (5 URLs) to `/about/`
  - `/dev/rs232`, a crawl artifact from a code snippet in FAQ47, to the cables accessory page

## Verification

- 47 of the 55 URLs that still 404 in production now resolve in the built site; the remaining 8 are deliberate 404s (deleted posts with no successor, removed tag pages, truncated crawler artifacts)
- All redirect targets verified to exist; full internal link scan passes
- 26 further URLs in the GSC report already resolve via pre-existing redirects and only need revalidation

## After deploy

In Search Console, go to Indexing → Pages and hit **Validate fix** on each issue type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)