### PR TITLE
Retry broken link check once before failing

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -20,8 +20,26 @@ jobs:
             ]
           }' \
           .github/workflows/markdown.links.config.json > "$GITHUB_WORKSPACE/.github/workflows/mlc.config.generated.json"
+    # First attempt. Allowed to fail: external hosts intermittently time out
+    # (Status: 0 / ETIMEDOUT), which markdown-link-check never retries because
+    # its retryOn429/retryCount settings only cover HTTP 429 responses.
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       id: checker
+      continue-on-error: true
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        config-file: '.github/workflows/mlc.config.generated.json'
+    - name: Cool off before retry
+      if: steps.checker.outcome == 'failure'
+      run: |
+        echo "First pass reported dead links; retrying once in 60s to rule out transient network failures."
+        sleep 60
+    # Second attempt. Not allowed to fail: if a link is still dead after the
+    # cool-off, treat it as genuine link rot and fail the job.
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      id: checker-retry
+      if: steps.checker.outcome == 'failure'
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'


### PR DESCRIPTION
Scheduled runs [#601](https://github.com/subnero1/subnero1.github.io/actions/runs/31769020834) and [#602](https://github.com/subnero1/subnero1.github.io/actions/runs/31989806659) failed on a single external host each:

| Run | Date | Failing link | Error |
|---|---|---|---|
| 601 | Aug 14 | `https://kr-asia.com/how-water-drones-can-help-singapore-sustain-its-water-sources` | ESOCKETTIMEDOUT |
| 602 | Aug 17 | `http://ieeeoes.org/` | ETIMEDOUT |

Both URLs return 200 when probed now (`ieeeoes.org` in ~3s, `kr-asia.com` in ~1s), and runs #603 and #604 passed with no code changes. `Status: 0` means no HTTP response at all, so these were transient network failures, not link rot.

## Why the existing config did not help

`markdown.links.config.json` sets `retryOn429: true` and `retryCount: 5`, but `markdown-link-check` only retries on HTTP **429**. A connect/socket timeout produces no status code and fails immediately, so one slow external host fails the whole scheduled run.

## Change

`nick-fields/retry` cannot wrap this step, since it only retries a shell `command` and the link checker is a `uses:` Docker action. This uses the native Actions equivalent:

- **Attempt 1** gets `continue-on-error: true`, so a flaky timeout no longer fails the job outright.
- **Cool-off** step runs only `if: steps.checker.outcome == 'failure'` and sleeps 60s.
- **Attempt 2** runs under the same condition with *no* `continue-on-error`, so a link still dead after the cool-off fails the job as before.

## Effect on past runs

- #601 and #602 (transient timeouts) → retry passes, job green.
- #600 (genuinely broken `{{site.baseurl}}` image paths, fixed in a0cd211/d8be468) → still fails, as it should.

Cost is a second full pass (~3-5 min) only on runs that would otherwise have failed. Green runs are unaffected.

Workflow YAML validated; step graph confirmed as 5 steps with the conditions wired as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHwhD9eWf9fdGKz5hqdk4D